### PR TITLE
bugfix: string with length 1 throws exception

### DIFF
--- a/Source/GenCode128/Code128Content.cs
+++ b/Source/GenCode128/Code128Content.cs
@@ -37,7 +37,7 @@ namespace GenCode128
             var csa1 = asciiBytes.Length > 0
                            ? Code128Code.CodesetAllowedForChar(asciiBytes[0])
                            : Code128Code.CodeSetAllowed.CodeAorB;
-            var csa2 = asciiBytes.Length > 0
+            var csa2 = asciiBytes.Length > 1
                            ? Code128Code.CodesetAllowedForChar(asciiBytes[1])
                            : Code128Code.CodeSetAllowed.CodeAorB;
             var currentCodeSet = this.GetBestStartSet(csa1, csa2);

--- a/Source/GenCode128Tests/ContentTest.cs
+++ b/Source/GenCode128Tests/ContentTest.cs
@@ -372,5 +372,17 @@ namespace GenCode128Tests
             result = content.Codes;
             Assert.AreEqual(10, result.Length, "Wrong number of code values in result");
         }
+
+        [Test]
+        public void OneCharStringTest()
+        {
+            var content = new Code128Content("0");
+            var result = content.Codes;
+            Assert.AreEqual(4, result.Length, "Wrong number of code values in result");
+            Assert.AreEqual(104, result[0], "Start code wrong");
+            Assert.AreEqual(16, result[1], "Code value #1 wrong");
+            Assert.AreEqual(17, result[2], "Checksum wrong");
+            Assert.AreEqual(106, result[3], "Stop character wrong");
+        }
     }
 }


### PR DESCRIPTION
An exception accured when string has length 1
Looks like bug related to copy past. I added a fix and test.